### PR TITLE
feat(version): bareos 23 major release, set it as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ bareos_repository_release: current
 
 # The version of Bareos to install.
 # Only affects `bareos_repository_type: subscription`.
-bareos_repository_version: 22
+bareos_repository_version: 23
 
 # You can enable tracebacks for troubleshooting purposes.
 bareos_repository_enable_tracebacks: no

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,7 +16,7 @@ bareos_repository_release: current
 
 # The version of Bareos to install.
 # Only affects `bareos_repository_type: subscription`.
-bareos_repository_version: 22
+bareos_repository_version: 23
 
 # You can enable tracebacks for troubleshooting purposes.
 bareos_repository_enable_tracebacks: no

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -33,7 +33,7 @@ argument_specs:
           - release
       bareos_repository_version:
         type: "int"
-        default: 22
+        default: 23
         description: "The version of Bareos to install. Only affects `bareos_repository_type: subscription`."
       bareos_repository_enable_tracebacks:
         type: "bool"

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -39,7 +39,7 @@
     that:
       - bareos_repository_version is defined
       - bareos_repository_version is number
-      - bareos_repository_version in [ 20, 21, 22 ]
+      - bareos_repository_version in [ 20, 21, 22, 23 ]
     quiet: yes
   when:
     - bareos_repository_type == "subscription"


### PR DESCRIPTION
Bareos version 23.0.0 has been released on 2023-12-13.

Ref: https://github.com/bareos/bareos/releases/tag/Release%2F23.0.0