### PR TITLE
fix(suse): missing credentials string repo url

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -19,7 +19,7 @@ _bareos_repository_url:
     default: "{{ bareos_repository_base_url }}/{{ bareos_repository_release }}/{{ bareos_repository_version }}/{{ ansible_distribution }}_{{ ansible_distribution_major_version }}"
     Fedora: "{{ bareos_repository_base_url }}/{{ bareos_repository_release }}/{{ bareos_repository_version }}/{{ ansible_distribution }}_{{ ansible_distribution_major_version }}"
     RedHat: "{{ bareos_repository_base_url }}/{{ bareos_repository_release }}/{{ bareos_repository_version }}/EL_{{ ansible_distribution_major_version }}"
-    Suse: "{{ bareos_repository_base_url }}/{{ bareos_repository_release }}/{{ bareos_repository_version }}/SUSE_{{ ansible_distribution_major_version }}"
+    Suse: "{{ bareos_repository_base_url }}/{{ bareos_repository_release }}/{{ bareos_repository_version }}/SUSE_{{ ansible_distribution_major_version }}?credentials=bareos"
     Ubuntu: "{{ bareos_repository_base_url }}/{{ bareos_repository_release }}/{{ bareos_repository_version }}/xUbuntu_{{ ansible_distribution_version }}"
 bareos_repository_url: "{{ _bareos_repository_url[bareos_repository_type][ansible_distribution] | default(_bareos_repository_url[bareos_repository_type][ansible_os_family] | default(_bareos_repository_url[bareos_repository_type]['default'])) }}"
 


### PR DESCRIPTION
credentials argument needs to be provided in the repository URL or else the login fails