### PR TITLE
fix(suse): mv credential string in URL to zypper_repository task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -108,6 +108,20 @@
       loop: "{{ bareos_repository_list }}"
       loop_control:
         label: "{{ item.name }}"
+      when:
+        - bareos_repository_type != "subscription"
+
+    - name: Add repository (zypper) (subscription)
+      community.general.zypper_repository:
+        name: "{{ item.name }}"
+        # credential file needs to be appended to URL
+        repo: "{{ item.repo }}?credentials=bareos"
+        state: present
+      loop: "{{ bareos_repository_list }}"
+      loop_control:
+        label: "{{ item.name }}"
+      when:
+        - bareos_repository_type == "subscription"
 
 - name: Enable tracebacks
   when:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -19,7 +19,7 @@ _bareos_repository_url:
     default: "{{ bareos_repository_base_url }}/{{ bareos_repository_release }}/{{ bareos_repository_version }}/{{ ansible_distribution }}_{{ ansible_distribution_major_version }}"
     Fedora: "{{ bareos_repository_base_url }}/{{ bareos_repository_release }}/{{ bareos_repository_version }}/{{ ansible_distribution }}_{{ ansible_distribution_major_version }}"
     RedHat: "{{ bareos_repository_base_url }}/{{ bareos_repository_release }}/{{ bareos_repository_version }}/EL_{{ ansible_distribution_major_version }}"
-    Suse: "{{ bareos_repository_base_url }}/{{ bareos_repository_release }}/{{ bareos_repository_version }}/SUSE_{{ ansible_distribution_major_version }}?credentials=bareos"
+    Suse: "{{ bareos_repository_base_url }}/{{ bareos_repository_release }}/{{ bareos_repository_version }}/SUSE_{{ ansible_distribution_major_version }}"
     Ubuntu: "{{ bareos_repository_base_url }}/{{ bareos_repository_release }}/{{ bareos_repository_version }}/xUbuntu_{{ ansible_distribution_version }}"
 bareos_repository_url: "{{ _bareos_repository_url[bareos_repository_type][ansible_distribution] | default(_bareos_repository_url[bareos_repository_type][ansible_os_family] | default(_bareos_repository_url[bareos_repository_type]['default'])) }}"
 


### PR DESCRIPTION
Old approach added the credential string to the base URL, which was used for the GPG key URL too and therefore broke the key import.