### PR TITLE
fix(suse): disable autorefresh for subscription repo

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -116,6 +116,7 @@
         name: "{{ item.name }}"
         # credential file needs to be appended to URL
         repo: "{{ item.repo }}?credentials=bareos"
+        autorefresh: false  # avoid credential issues running zypper as non-root
         state: present
       loop: "{{ bareos_repository_list }}"
       loop_control:


### PR DESCRIPTION
as of now the bareos repo has set `autorefresh=1`, which causes zypper to try to update the repo with every operation and that is not allowed for unprivileged users. There's a hint in the zypper manual:
```
... This means, zypper will not even try to download and check the index files, and you will be able to use zypper for operations like search or info without internet access or root privileges.
```