### PR TITLE
fix: Debian missing gpg dependency

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,9 +28,11 @@
   when:
     - ansible_pkg_mgr in [ "apt" ]
   block:
-    - name: Install CA certificates (apt)
+    - name: Install dependencies for apt
       ansible.builtin.package:
-        name: ca-certificates
+        name:
+          - ca-certificates
+          - gpg
 
     - name: Download gpg key (apt)
       ansible.builtin.get_url:


### PR DESCRIPTION
Repository setup will fail for Debian 13 if gpg package is not installed beforehand.