### PR TITLE
feat(deb): switch to deb822 format for Debian 13+, Ubuntu 24+

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,7 @@
   ansible.builtin.command:
     cmd: pkg update
   changed_when: true
+
+- name: Apt update cache
+  ansible.builtin.apt:
+    update_cache: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,6 +69,40 @@
       loop: "{{ bareos_repository_list }}"
       loop_control:
         label: "{{ item.name }}"
+      when:
+        - ansible_facts.distribution == "Debian" and ansible_facts.distribution_major_version | int <= 12 or
+          ansible_facts.distribution == "Ubuntu" and ansible_facts.distribution_major_version | int <= 22
+
+    - name: Add repository (apt) deb822 format and remove old format
+      when:
+        - ansible_facts.distribution == "Debian" and ansible_facts.distribution_major_version | int >= 13 or
+          ansible_facts.distribution == "Ubuntu" and ansible_facts.distribution_major_version | int >= 24
+      block:
+        - name: Remove repository in old format
+          ansible.builtin.apt_repository:
+            repo: "{{ item.deb_repo }}"
+            state: absent
+          no_log: true
+          loop: "{{ bareos_repository_list }}"
+          loop_control:
+            label: "{{ item.name }}"
+
+        - name: Add repository (apt) deb822 format
+          ansible.builtin.deb822_repository:
+            name: "{{ item.name }}"
+            uris: "{{ item.repo }}"
+            enabled: true
+            types:
+              - deb
+              - deb-src
+            suites: /
+            signed_by: /etc/apt/bareos.gpg
+          no_log: true
+          loop: "{{ bareos_repository_list }}"
+          loop_control:
+            label: "{{ item.name }}"
+          notify:
+            - Apt update cache
 
 - name: Run tasks on zypper based distributions
   when:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,13 +71,13 @@
       loop_control:
         label: "{{ item.name }}"
       when:
-        - ansible_facts.distribution == "Debian" and ansible_facts.distribution_major_version | int <= 12 or
-          ansible_facts.distribution == "Ubuntu" and ansible_facts.distribution_major_version | int <= 22
+        - (ansible_facts.distribution == "Debian" and ansible_facts.distribution_major_version | int <= 12) or
+          (ansible_facts.distribution == "Ubuntu" and ansible_facts.distribution_major_version | int <= 22)
 
     - name: Add repository (apt) deb822 format and remove old format
       when:
-        - ansible_facts.distribution == "Debian" and ansible_facts.distribution_major_version | int >= 13 or
-          ansible_facts.distribution == "Ubuntu" and ansible_facts.distribution_major_version | int >= 24
+        - (ansible_facts.distribution == "Debian" and ansible_facts.distribution_major_version | int >= 13) or
+          (ansible_facts.distribution == "Ubuntu" and ansible_facts.distribution_major_version | int >= 24)
       block:
         - name: Remove repository in old format
           ansible.builtin.apt_repository:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,8 +32,8 @@
       ansible.builtin.package:
         name:
           - ca-certificates
-          - python3-debian
           - gpg
+          - python3-debian
 
     - name: Download gpg key (apt)
       ansible.builtin.get_url:
@@ -83,6 +83,7 @@
           ansible.builtin.apt_repository:
             repo: "{{ item.deb_repo }}"
             state: absent
+            update_cache: true
           no_log: true
           loop: "{{ bareos_repository_list }}"
           loop_control:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,6 +32,7 @@
       ansible.builtin.package:
         name:
           - ca-certificates
+          - python3-debian
           - gpg
 
     - name: Download gpg key (apt)


### PR DESCRIPTION
Additional task to setup the Bareos repository in deb822 format instead and remove the old one-line-style format repository.