### PR TITLE
fix: Avoid repository duplicates in same repo file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -66,6 +66,7 @@
         - bareos_repository_type == "subscription"
 
     # don't use apt_repository module as it cannot handle version changes in URL
+    # see: https://github.com/adfinis/ansible-role-bareos_repository/pull/30#issue-3875677300
     - name: Add repository (apt) 
       ansible.builtin.template:
         src: apt_repo.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,7 +68,7 @@
     # don't use apt_repository module as it cannot handle version changes in URL
     - name: Add repository (apt) 
       ansible.builtin.template:
-        src: templates/apt_repo.j2
+        src: apt_repo.j2
         dest: "/etc/apt/sources.list.d/{{ item.name }}.list"
         owner: root
         group: root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -81,13 +81,15 @@
         - Apt update cache
       when:
         - (ansible_facts.distribution == "Debian" and ansible_facts.distribution_major_version | int <= 12) or
-          (ansible_facts.distribution == "Ubuntu" and ansible_facts.distribution_major_version | int <= 22)
+          (ansible_facts.distribution == "Ubuntu" and ansible_facts.distribution_major_version | int <= 22) or
+          (ansible_facts.distribution == "Univention Corporate Server" and ansible_distribution_version is version("5.2", "<"))
 
     - name: Add repository (apt) deb822 format and remove old format
       when:
         - (ansible_facts.distribution == "Debian" and ansible_facts.distribution_major_version | int >= 13) or
           (ansible_facts.distribution == "Ubuntu" and ansible_facts.distribution_major_version | int >= 24) or
-          (ansible_facts.distribution == "Univention Corporate Server") # distribution only set to this in UCS 5.2
+          (ansible_facts.distribution == "Univention Corporate Server" and ansible_distribution_version is version("5.2", ">="))
+
       block:
 
         # use file rather than apt_repository module, to avoid possible issues during repo version changes,

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -80,12 +80,13 @@
         - Apt update cache
       when:
         - (ansible_facts.distribution == "Debian" and ansible_facts.distribution_major_version | int <= 12) or
-          (ansible_facts.distribution == "Ubuntu" and ansible_facts.distribution_major_version | int <= 22) 
+          (ansible_facts.distribution == "Ubuntu" and ansible_facts.distribution_major_version | int <= 22)
 
     - name: Add repository (apt) deb822 format and remove old format
       when:
         - (ansible_facts.distribution == "Debian" and ansible_facts.distribution_major_version | int >= 13) or
-          (ansible_facts.distribution == "Ubuntu" and ansible_facts.distribution_major_version | int >= 24)
+          (ansible_facts.distribution == "Ubuntu" and ansible_facts.distribution_major_version | int >= 24) or
+          (ansible_facts.distribution == "Univention Corporate Server") # distribution only set to this in UCS 5.2
       block:
 
         # use file rather than apt_repository module, to avoid possible issues during repo version changes,

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,13 +65,14 @@
       when:
         - bareos_repository_type == "subscription"
 
-    - name: Add repository (apt)
-      ansible.builtin.apt_repository:
-        repo: "{{ item.deb_repo }}"
-        state: present
-        filename: "{{ item.name }}"
-        # use handler instead to avoid issues with version/gpg key changes
-        update_cache: false
+    # don't use apt_repository module as it cannot handle version changes in URL
+    - name: Add repository (apt) 
+      ansible.builtin.template:
+        src: templates/apt_repo.j2
+        dest: "/etc/apt/sources.list.d/{{ item.name }}.list"
+        owner: root
+        group: root
+        mode: "0644"
       loop: "{{ bareos_repository_list }}"
       loop_control:
         label: "{{ item.name }}"
@@ -79,7 +80,7 @@
         - Apt update cache
       when:
         - (ansible_facts.distribution == "Debian" and ansible_facts.distribution_major_version | int <= 12) or
-          (ansible_facts.distribution == "Ubuntu" and ansible_facts.distribution_major_version | int <= 22)
+          (ansible_facts.distribution == "Ubuntu" and ansible_facts.distribution_major_version | int <= 22) 
 
     - name: Add repository (apt) deb822 format and remove old format
       when:

--- a/templates/apt_repo.j2
+++ b/templates/apt_repo.j2
@@ -1,0 +1,2 @@
+{{ ansible_managed | comment }}
+{{ item.deb_repo }}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -57,6 +57,7 @@ bareos_repository_debug_list:
     baseurl: "{{ bareos_repository_url }}/debug"
     gpgkey: "{{ bareos_repository_gpg_key }}"
     repo: "{{ bareos_repository_url }}/debug"
+    deb_repo: "deb [signed-by=/etc/apt/bareos.gpg] {{ bareos_repository_url }}/debug /"
     username: "{{ bareos_repository_username | default(omit) }}"
     password: "{{ bareos_repository_password | default(omit) }}"
 


### PR DESCRIPTION
Avoid module behavior like this by using `ansible.builtin.template` instead of `apt_repository`
```
deb [signed-by=/etc/apt/bareos.gpg] https://download.bareos.com/bareos/release/24/Debian_12 /
deb [signed-by=/etc/apt/bareos.gpg] https://download.bareos.com/bareos/release/25/Debian_12 /
```