### PR TITLE
fix: Apt keyring location parameter

### DIFF
--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -14,6 +14,18 @@
     bareos_repository_verify_packages: "{{ _bareos_repository_verify_packages[ansible_os_family] | default(_bareos_repository_verify_packages['default']) }}"
 
   tasks:
+
+    - name: Test repositories (apt update)
+      ansible.builtin.apt:
+        update_cache: true
+      when: ansible_facts.os_family == 'Debian'
+
+    - name: Test repositories (dnf update cache)
+      ansible.builtin.dnf:
+        update_cache: true
+      when:
+        - ansible_facts.os_family == "RedHat"
+
     - name: Test if bareos packages can be installed
       ansible.builtin.package:
         name: "{{ bareos_repository_verify_packages }}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-# Pinning ansible-compat version due to [bug](https://github.com/ansible-community/molecule/issues/3903)
 ansible-compat == 25.*
 molecule == 25.*
 molecule-plugins[docker] == 25.*

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,15 +40,15 @@
     - name: Download gpg key (apt)
       ansible.builtin.get_url:
         url: "{{ bareos_repository_gpg_key }}"
-        dest: /etc/apt/bareos.gpg
+        dest: /etc/apt/keyrings/bareos.gpg
         username: "{{ bareos_repository_username }}"
         password: "{{ bareos_repository_password }}"
-        force: true # required so file is replaced if upstream key changes
+        force: true  # required so file is replaced if upstream key changes
         owner: root
         group: root
         mode: "0644"
       no_log: true
-      changed_when: false # avoid reporting a change due to force: true
+      changed_when: false  # avoid reporting a change due to force: true
 
     - name: Place credentials file (apt)
       ansible.builtin.copy:
@@ -67,7 +67,7 @@
 
     # don't use apt_repository module as it cannot handle version changes in URL
     # see: https://github.com/adfinis/ansible-role-bareos_repository/pull/30#issue-3875677300
-    - name: Add repository (apt) 
+    - name: Add repository (apt)
       ansible.builtin.template:
         src: apt_repo.j2
         dest: "/etc/apt/sources.list.d/{{ item.name }}.list"
@@ -114,7 +114,7 @@
               - deb
               - deb-src
             suites: /
-            signed_by: /etc/apt/bareos.gpg
+            signed_by: /etc/apt/keyrings/bareos.gpg
           loop: "{{ bareos_repository_list }}"
           loop_control:
             label: "{{ item.name }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -121,6 +121,13 @@
           notify:
             - Apt update cache
 
+    # gpg key was initially placed in /etc/apt/bareos.gpg.
+    # now it's placed in /etc/apt/keyrings/ and this task makes sure the key is cleaned-up.
+    - name: Remove key in former location (apt)
+      ansible.builtin.file:
+        path: /etc/apt/bareos.gpg
+        state: absent
+
 - name: Run tasks on zypper based distributions
   when:
     - ansible_pkg_mgr in [ "zypper" ]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,7 +40,7 @@
     - name: Download gpg key (apt)
       ansible.builtin.get_url:
         url: "{{ bareos_repository_gpg_key }}"
-        dest: /etc/apt/keyrings/bareos.gpg
+        dest: "{{ bareos_repository_gpg_key_path }}"
         username: "{{ bareos_repository_username }}"
         password: "{{ bareos_repository_password }}"
         force: true  # required so file is replaced if upstream key changes
@@ -114,7 +114,7 @@
               - deb
               - deb-src
             suites: /
-            signed_by: /etc/apt/keyrings/bareos.gpg
+            signed_by: "{{ bareos_repository_gpg_key_path }}"
           loop: "{{ bareos_repository_list }}"
           loop_control:
             label: "{{ item.name }}"
@@ -128,7 +128,7 @@
     - name: Download gpg key (zypper)
       ansible.builtin.get_url:
         url: "{{ bareos_repository_gpg_key }}"
-        dest: /etc/gnupg/bareos.gpg
+        dest: "{{ bareos_repository_gpg_key_path }}"
         username: "{{ bareos_repository_username }}"
         password: "{{ bareos_repository_password }}"
         owner: root
@@ -138,7 +138,7 @@
 
     - name: Import gpg key (zypper)
       ansible.builtin.rpm_key:
-        key: /etc/gnupg/bareos.gpg
+        key: "{{ bareos_repository_gpg_key_path }}"
 
     - name: Place credentials file (zypper)
       ansible.builtin.copy:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -39,13 +39,13 @@ _bareos_repository_gpg_key:
 
 bareos_repository_gpg_key: "{{ _bareos_repository_gpg_key[ansible_os_family] | default(_bareos_repository_gpg_key['default']) }}"
 
-_bares_repository_gpg_key_path:
-  default: "none" # path is not required on RHEL based distros
+_bareos_repository_gpg_key_path:
+  default: "none"  # path is not required on RHEL based distros
   Suse: /etc/gnupg/bareos.gpg
   Debian: /etc/apt/keyrings/bareos.gpg
   Debian_11: /etc/apt/trusted.gpg.d/bareos.gpg
 
-bareos_repository_gpg_key_path: "{{ _bareos_repository_gpg_key_path[ansible_os_family + '_' + ansible_distribution_major_version] | default(_bareos_repository_gpg_key_path[ansible_os_family]) | default(_bareos_repository_gpg_key['default']) }}"
+bareos_repository_gpg_key_path: "{{ _bareos_repository_gpg_key_path[(ansible_os_family + '_' + ansible_distribution_major_version)] | default(_bareos_repository_gpg_key_path[ansible_os_family]) | default(_bareos_repository_gpg_key_path['default']) }}"
 
 # A list of repositories. The items in this list contains parameters for both dnf/yum, apt and zypperz.
 bareos_repository_list:
@@ -54,7 +54,7 @@ bareos_repository_list:
     baseurl: "{{ bareos_repository_url }}"
     gpgkey: "{{ bareos_repository_gpg_key }}"
     repo: "{{ bareos_repository_url }}"
-    deb_repo: "deb [signed-by=/etc/apt/keyrings/bareos.gpg] {{ bareos_repository_url }} /"
+    deb_repo: "deb [signed-by={{ bareos_repository_gpg_key_path }}] {{ bareos_repository_url }} /"
     username: "{{ bareos_repository_username | default(omit) }}"
     password: "{{ bareos_repository_password | default(omit) }}"
 
@@ -65,7 +65,7 @@ bareos_repository_debug_list:
     baseurl: "{{ bareos_repository_url }}/debug"
     gpgkey: "{{ bareos_repository_gpg_key }}"
     repo: "{{ bareos_repository_url }}/debug"
-    deb_repo: "deb [signed-by=/etc/apt/keyrings/bareos.gpg] {{ bareos_repository_url }}/debug /"
+    deb_repo: "deb [signed-by={{ bareos_repository_gpg_key_path }}] {{ bareos_repository_url }}/debug /"
     username: "{{ bareos_repository_username | default(omit) }}"
     password: "{{ bareos_repository_password | default(omit) }}"
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -46,7 +46,7 @@ bareos_repository_list:
     baseurl: "{{ bareos_repository_url }}"
     gpgkey: "{{ bareos_repository_gpg_key }}"
     repo: "{{ bareos_repository_url }}"
-    deb_repo: "deb [signed-by=/etc/apt/bareos.gpg] {{ bareos_repository_url }} /"
+    deb_repo: "deb [signed-by=/etc/apt/keyrings/bareos.gpg] {{ bareos_repository_url }} /"
     username: "{{ bareos_repository_username | default(omit) }}"
     password: "{{ bareos_repository_password | default(omit) }}"
 
@@ -57,7 +57,7 @@ bareos_repository_debug_list:
     baseurl: "{{ bareos_repository_url }}/debug"
     gpgkey: "{{ bareos_repository_gpg_key }}"
     repo: "{{ bareos_repository_url }}/debug"
-    deb_repo: "deb [signed-by=/etc/apt/bareos.gpg] {{ bareos_repository_url }}/debug /"
+    deb_repo: "deb [signed-by=/etc/apt/keyrings/bareos.gpg] {{ bareos_repository_url }}/debug /"
     username: "{{ bareos_repository_username | default(omit) }}"
     password: "{{ bareos_repository_password | default(omit) }}"
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -39,6 +39,14 @@ _bareos_repository_gpg_key:
 
 bareos_repository_gpg_key: "{{ _bareos_repository_gpg_key[ansible_os_family] | default(_bareos_repository_gpg_key['default']) }}"
 
+_bares_repository_gpg_key_path:
+  default: "none" # path is not required on RHEL based distros
+  Suse: /etc/gnupg/bareos.gpg
+  Debian: /etc/apt/keyrings/bareos.gpg
+  Debian_11: /etc/apt/trusted.gpg.d/bareos.gpg
+
+bareos_repository_gpg_key_path: "{{ _bareos_repository_gpg_key_path[ansible_os_family + '_' + ansible_distribution_major_version] | default(_bareos_repository_gpg_key_path[ansible_os_family]) | default(_bareos_repository_gpg_key['default']) }}"
+
 # A list of repositories. The items in this list contains parameters for both dnf/yum, apt and zypperz.
 bareos_repository_list:
   - name: bareos


### PR DESCRIPTION
Define destination path for repository gpg key as variable `bareos_repository_gpg_key_path`.

Switches destination path from `/etc/apt/bareos.gpg` to `/etc/apt/keyrings/bareos.gpg` on Debian 12+ and `/etc/apt/trusted.gpg.d/bareos.gpg` on Debian 11 for backwards compatibility.

Fixes https://github.com/adfinis/ansible-role-bareos_repository/issues/32